### PR TITLE
broadcast friendly name for delta messages types

### DIFF
--- a/src/Delta.proto
+++ b/src/Delta.proto
@@ -27,7 +27,7 @@ import "Common.proto";
 package Catalyst.Protocol.Delta;
 
 /**
- * Delta
+ * DeltaBroadcast
  *
  * version:
  * PreviousDeltaDfsHash: address for the content of the previous delta on the DFS
@@ -38,7 +38,7 @@ package Catalyst.Protocol.Delta;
  * CFEntries:
  * CBEntries: one per active worker
  */
- message Delta {
+ message DeltaBroadcast {
 	uint32 Version = 1; 
 	bytes PreviousDeltaDfsHash = 2;
 	bytes MerkleRoot = 3;
@@ -50,14 +50,14 @@ package Catalyst.Protocol.Delta;
 }
 
 /**
- * CandidateDelta
+ * CandidateDeltaBroadcast
  *
  * DeltaHash: The hash computed for the current delta produced by ProducerId.
  *	This is meant to be used when voting for most popular hashes.
  * PreviousDeltaDfsHash: DFS address for the content of the delta preceding this candidate.
  * ProducerId: Identifier of the producer of the candidate.
  */
-message CandidateDelta {
+message CandidateDeltaBroadcast {
 	bytes Hash = 1;
 	Common.PeerId ProducerId = 2;
 	bytes PreviousDeltaDfsHash = 3;

--- a/src/Delta.proto
+++ b/src/Delta.proto
@@ -27,7 +27,7 @@ import "Common.proto";
 package Catalyst.Protocol.Delta;
 
 /**
- * DeltaBroadcast
+ * Delta
  *
  * version:
  * PreviousDeltaDfsHash: address for the content of the previous delta on the DFS
@@ -38,7 +38,7 @@ package Catalyst.Protocol.Delta;
  * CFEntries:
  * CBEntries: one per active worker
  */
- message DeltaBroadcast {
+ message Delta {
 	uint32 Version = 1; 
 	bytes PreviousDeltaDfsHash = 2;
 	bytes MerkleRoot = 3;


### PR DESCRIPTION
This change is to allow Delta and CandidateDelta message types to be broadcast