### PR TITLE
Refactor any signed to be able to sign all message contents

### DIFF
--- a/src/Common.proto
+++ b/src/Common.proto
@@ -37,9 +37,9 @@ message PeerId {
 * A wrapper around the service message, the contents of service message should be signed by the sender to avoid tampering mid-transit.
 * To verify use message.peerId.publicKey
 */
-message SignedEnvelope {
+message ProtocolMessageSigned {
     bytes signature = 1;
-    ServiceMessage message = 2;
+    ProtocolMessage message = 2;
 }
 
 /**
@@ -49,7 +49,7 @@ message SignedEnvelope {
 * - type_url is the shortened protocol name of the message type being encoded in the value field (cf Any from protobuf WellKnownTypes)
 * - value is the actual value of the message being wrapped (cf Any from protobuf WellKnownTypes)
 */
-message ServiceMessage {
+message ProtocolMessage {
     PeerId peerId = 1;
     bytes correlationId = 2;
     string type_url = 3;

--- a/src/Common.proto
+++ b/src/Common.proto
@@ -34,17 +34,24 @@ message PeerId {
 }
 
 /**
-* Wrapper to be used to send any message on the network
+* A wrapper around the service message, the contents of service message should be signed by the sender to avoid tampering mid-transit.
+* To verify use message.peerId.publicKey
+*/
+message SignedEnvelope {
+    bytes signature = 1;
+    ServiceMessage message = 2;
+}
+
+/**
+* Core protocol messages to be sent across the network.
 * - peerId is the sender's peerId
 * - correlationId is a 16 bytes guid used to match responses to their original requests
-* - signature is the correlationId + value signed by the sender's and verifiable using peerId.publicKey
 * - type_url is the shortened protocol name of the message type being encoded in the value field (cf Any from protobuf WellKnownTypes)
 * - value is the actual value of the message being wrapped (cf Any from protobuf WellKnownTypes)
 */
-message AnySigned {
+message ServiceMessage {
     PeerId peerId = 1;
     bytes correlationId = 2;
-    bytes signature = 3;
-    string type_url = 4;
-    bytes value = 5;
+    string type_url = 3;
+    bytes value = 4;
 }


### PR DESCRIPTION
We should sign all message content to avoid tampering mid-transit of the network.