### PR TITLE
42 new delta hash broadcast

### DIFF
--- a/src/Delta.proto
+++ b/src/Delta.proto
@@ -54,7 +54,7 @@ package Catalyst.Protocol.Delta;
  *
  * DeltaHash: The hash computed for the current delta produced by ProducerId.
  *	This is meant to be used when voting for most popular hashes.
- * PreviousDeltaDfsHash: DFS address for the content of the delta preceding this candidate.
+ * PreviousDeltaDfsHash: The DFS address for the content of the delta preceding this candidate.
  * ProducerId: Identifier of the producer of the candidate.
  */
 message CandidateDeltaBroadcast {
@@ -77,8 +77,8 @@ message FavouriteDeltaBroadcast {
 /**
  * DeltaDfsHashBroadcast
  *
- * DeltaDfsHash: The address at which the full content of the delta can be retrieved.
- * PreviousDeltaDfsHash: DFS address for the content of the delta preceding this candidate.
+ * DeltaDfsHash: The DFS address at which the full content of the delta can be retrieved.
+ * PreviousDeltaDfsHash: The DFS address for the content of the delta preceding this candidate.
  */
  message DeltaDfsHashBroadcast {
 	bytes DeltaDfsHash = 1;

--- a/src/Delta.proto
+++ b/src/Delta.proto
@@ -73,3 +73,14 @@ message FavouriteDeltaBroadcast {
 	CandidateDeltaBroadcast Candidate = 1;
 	Common.PeerId VoterId = 2;
 }
+
+/**
+ * DeltaDfsAddressBroadcast
+ *
+ * DeltaDfsHash: The address at which the full content of the delta can be retrieved.
+ * PreviousDeltaDfsHash: DFS address for the content of the delta preceding this candidate.
+ */
+ message DeltaDfsAddressBroadcast {
+	bytes DeltaDfsHash = 1;
+	bytes PreviousDeltaDfsHash = 2;
+}

--- a/src/Delta.proto
+++ b/src/Delta.proto
@@ -75,12 +75,12 @@ message FavouriteDeltaBroadcast {
 }
 
 /**
- * DeltaDfsAddressBroadcast
+ * DeltaDfsHashBroadcast
  *
  * DeltaDfsHash: The address at which the full content of the delta can be retrieved.
  * PreviousDeltaDfsHash: DFS address for the content of the delta preceding this candidate.
  */
- message DeltaDfsAddressBroadcast {
+ message DeltaDfsHashBroadcast {
 	bytes DeltaDfsHash = 1;
 	bytes PreviousDeltaDfsHash = 2;
 }


### PR DESCRIPTION
this is needed in order to broadcast the hash of ledger state updates as they get confirmed and appear on the DFS.
closes #42 