### PR TITLE
Move namespace from Delta to Deltas

### DIFF
--- a/src/Deltas.proto
+++ b/src/Deltas.proto
@@ -23,7 +23,6 @@ option java_multiple_files = true;
 
 import "Transaction.proto";
 import "Common.proto";
-import "google/protobuf/timestamp.proto";
 
 package Catalyst.Protocol.Deltas;
 
@@ -44,7 +43,7 @@ package Catalyst.Protocol.Deltas;
 	bytes PreviousDeltaDfsHash = 2;
 	bytes MerkleRoot = 3;
 	bytes MerklePoda = 4;
-	google.protobuf.Timestamp TimeStamp = 5;
+	uint32  TimeStamp = 5;
 	repeated Transaction.STTransactionEntry STEntries = 6;
 	repeated Transaction.CFTransactionEntry CFEntries = 7;
 	repeated Transaction.CoinbaseEntry CBEntries = 8;

--- a/src/Deltas.proto
+++ b/src/Deltas.proto
@@ -23,8 +23,9 @@ option java_multiple_files = true;
 
 import "Transaction.proto";
 import "Common.proto";
+import "google/protobuf/timestamp.proto";
 
-package Catalyst.Protocol.Delta;
+package Catalyst.Protocol.Deltas;
 
 /**
  * Delta
@@ -43,7 +44,7 @@ package Catalyst.Protocol.Delta;
 	bytes PreviousDeltaDfsHash = 2;
 	bytes MerkleRoot = 3;
 	bytes MerklePoda = 4;
-	uint32 TimeStamp = 5;
+	google.protobuf.Timestamp TimeStamp = 5;
 	repeated Transaction.STTransactionEntry STEntries = 6;
 	repeated Transaction.CFTransactionEntry CFEntries = 7;
 	repeated Transaction.CoinbaseEntry CBEntries = 8;

--- a/src/Deltas.proto
+++ b/src/Deltas.proto
@@ -23,6 +23,7 @@ option java_multiple_files = true;
 
 import "Transaction.proto";
 import "Common.proto";
+import "google/protobuf/timestamp.proto";
 
 package Catalyst.Protocol.Deltas;
 
@@ -43,7 +44,7 @@ package Catalyst.Protocol.Deltas;
 	bytes PreviousDeltaDfsHash = 2;
 	bytes MerkleRoot = 3;
 	bytes MerklePoda = 4;
-	uint32  TimeStamp = 5;
+	google.protobuf.Timestamp TimeStamp = 5;
 	repeated Transaction.STTransactionEntry STEntries = 6;
 	repeated Transaction.CFTransactionEntry CFEntries = 7;
 	repeated Transaction.CoinbaseEntry CBEntries = 8;

--- a/src/Rpc.proto
+++ b/src/Rpc.proto
@@ -219,7 +219,7 @@ message GetDeltaRequest {
 }
 
 message GetDeltaResponse {
-    Delta.Delta Delta = 1;
+    Deltas.Delta Delta = 1;
 }
 
 message GetMempoolRequest {

--- a/src/Rpc.proto
+++ b/src/Rpc.proto
@@ -24,7 +24,7 @@ option java_multiple_files = true;
 package Catalyst.Protocol.Rpc.Node;
 
 import "Common.proto";
-import "Delta.proto";
+import "Deltas.proto";
 
 message VersionRequest {
     bool query = 1;


### PR DESCRIPTION
closes #51 
1) Delta as a namespace is renamed to Deltas
~2) use TimeStamp from protobuff known types to represent the timestamp in the delta~
done in a separate PR https://github.com/catalyst-network/protocol-protobuffs/pull/54