### PR TITLE
Proto changes seperate conf and Public transactions

### DIFF
--- a/src/Rpc.proto
+++ b/src/Rpc.proto
@@ -136,8 +136,16 @@ message BroadcastPublicTransactionRequest {
 	Transaction.PublicTransaction transaction = 1;
 }
 
-message BroadcastRawTransactionResponse {
+message BroadcastConfidentialTransactionRequest {
+	Transaction.ConfidentialTransaction transaction = 1;
+}
+
+message BroadcastPublicTransactionResponse {
     ResponseCode responseCode = 1;
+}
+
+message BroadcastConfidentialTransactionResponse {
+	ResponseCode responseCode = 1;
 }
 
 message SendToRequest {

--- a/src/Rpc.proto
+++ b/src/Rpc.proto
@@ -132,8 +132,8 @@ message DecodeRawTransactionResponse {
     string query = 1;
 }
 
-message BroadcastRawTransactionRequest {
-	Transaction.TransactionBroadcast transaction = 1;
+message BroadcastPublicTransactionRequest {
+	Transaction.PublicTransaction transaction = 1;
 }
 
 message BroadcastRawTransactionResponse {
@@ -237,7 +237,8 @@ message GetMempoolRequest {
 }
 
 message GetMempoolResponse {
-    repeated Transaction.TransactionBroadcast transactions = 1;
+    repeated Transaction.PublicTransaction PublicTransactions = 1;
+    repeated Transaction.ConfidentialTransaction ConfidentialTransactions = 2;
 }
 
 message SignMessageRequest {

--- a/src/Transaction.proto
+++ b/src/Transaction.proto
@@ -36,6 +36,8 @@ package Catalyst.Protocol.Transaction;
  * CFEntries: 0 field for non-confidential transaction
  * Signature: 64 bytes
  * EntryRangeProof: 0 field for non-confidential transaction
+ * Init: 0 field used for smart contract deployment
+ * Data: 0 field used for smart contracts method calls
  */
 message PublicTransactionBroadcast {
 	PublicTransaction Transaction = 1;

--- a/src/Transaction.proto
+++ b/src/Transaction.proto
@@ -37,15 +37,34 @@ package Catalyst.Protocol.Transaction;
  * Signature: 64 bytes
  * EntryRangeProof: 0 field for non-confidential transaction
  */
-message TransactionBroadcast {
-    uint32 Version = 1;
-    google.protobuf.Timestamp TimeStamp = 2;
-    uint64 TransactionFees = 3;
-    uint64 LockTime = 4;
-    repeated STTransactionEntry STEntries = 5;
-    repeated CFTransactionEntry CFEntries = 6;
-    TransactionSignature Signature = 7; 
-    repeated EntryRangeProof EntryRangeProofs = 8;
+message PublicTransactionBroadcast {
+	PublicTransaction Transaction = 1;
+}
+
+message ConfidentialTransactionBroadcast {
+	ConfidentialTransaction Transaction = 1;
+}
+
+message BaseTransaction {
+	google.protobuf.Timestamp TimeStamp = 1;
+	uint64 TransactionFees = 2;
+	uint64 LockTime = 3;
+	uint32 Version = 4;
+	bytes From = 5;	
+	bytes Signature = 6;
+}
+
+message ConfidentialTransaction {
+	BaseTransaction BaseTransaction = 1;	
+	repeated CFTransactionEntry CFEntries = 2;
+	repeated EntryRangeProof EntryRangeProofs = 3;
+}
+
+message PublicTransaction {
+	BaseTransaction BaseTransaction = 1;
+	repeated STTransactionEntry STEntries = 2;
+	bytes Init = 3;
+	bytes Data = 4;
 }
 
 /**
@@ -56,7 +75,7 @@ message TransactionBroadcast {
  */
 message STTransactionEntry {
     bytes PubKey = 1;
-    sint64 Amount = 2;
+    uint64 Amount = 2;
 }
  
 /**
@@ -68,18 +87,6 @@ message STTransactionEntry {
 message CFTransactionEntry { 
     bytes PubKey = 1;
     bytes PedersenCommit = 2;
-}
-
-/**
- * TransactionSignature
- *
- * 1 aggregated signature per transaction  (s: SchnorrSignature; B: SchnorrComponent),
- * SchnorrSignature: 32 bytes, 
- * SchnorrComponent: 32 bytes
- */
-message TransactionSignature {
-    bytes SchnorrSignature = 1;
-    bytes SchnorrComponent = 2;
 }
 
 /**


### PR DESCRIPTION
Changes to separate conf and Public transactions.

Public transactions now have +ve amount entries as a from field has been added so we know what direction it is going in.

Extra fields such as Data and Init have been added for contract calls and contract deployments.