### PR TITLE
Modified transaction structure

### DIFF
--- a/src/Transaction.proto
+++ b/src/Transaction.proto
@@ -25,6 +25,11 @@ import "google/protobuf/timestamp.proto";
 
 package Catalyst.Protocol.Transaction;
 
+enum TransactionType {
+	NORMAL = 0;
+	CONFIDENTIAL = 1;
+}
+
 /**
  * Transaction
  *
@@ -36,16 +41,22 @@ package Catalyst.Protocol.Transaction;
  * CFEntries: 0 field for non-confidential transaction
  * Signature: 64 bytes
  * EntryRangeProof: 0 field for non-confidential transaction
+ * Init: 0 field for smart contract deployment
+ * Data: 0 field for smart contract calls
+ * From: Public key from address
  */
 message TransactionBroadcast {
-    uint32 Version = 1;
+	TransactionType TransactionType = 1;
     google.protobuf.Timestamp TimeStamp = 2;
     uint64 TransactionFees = 3;
     uint64 LockTime = 4;
     repeated STTransactionEntry STEntries = 5;
     repeated CFTransactionEntry CFEntries = 6;
-    TransactionSignature Signature = 7; 
+    bytes Signature = 7; 
     repeated EntryRangeProof EntryRangeProofs = 8;
+	bytes Init = 9;
+	bytes Data = 10;
+	bytes From = 11;
 }
 
 /**
@@ -56,7 +67,7 @@ message TransactionBroadcast {
  */
 message STTransactionEntry {
     bytes PubKey = 1;
-    sint64 Amount = 2;
+    uint64 Amount = 2;
 }
  
 /**
@@ -68,18 +79,6 @@ message STTransactionEntry {
 message CFTransactionEntry { 
     bytes PubKey = 1;
     bytes PedersenCommit = 2;
-}
-
-/**
- * TransactionSignature
- *
- * 1 aggregated signature per transaction  (s: SchnorrSignature; B: SchnorrComponent),
- * SchnorrSignature: 32 bytes, 
- * SchnorrComponent: 32 bytes
- */
-message TransactionSignature {
-    bytes SchnorrSignature = 1;
-    bytes SchnorrComponent = 2;
 }
 
 /**

--- a/src/Transaction.proto
+++ b/src/Transaction.proto
@@ -43,7 +43,7 @@ enum TransactionType {
  * EntryRangeProof: 0 field for non-confidential transaction
  * Init: 0 field for smart contract deployment
  * Data: 0 field for smart contract calls
- * From: Public key from address
+ * From: PubKey: 32 bytes, (255 bits or 256 with last bit to 0) public key (account address derived from the public key)
  */
 message TransactionBroadcast {
 	TransactionType TransactionType = 1;

--- a/src/Transaction.proto
+++ b/src/Transaction.proto
@@ -78,7 +78,7 @@ message STTransactionEntry {
 message CFTransactionEntry { 
     bytes PubKey = 1;
     bytes PedersenCommit = 2;
-    EntryRangeProof EntryRangeProofs = 8;
+    EntryRangeProof EntryRangeProofs = 3;
 }
 
 /**

--- a/src/Transaction.proto
+++ b/src/Transaction.proto
@@ -33,7 +33,7 @@ enum TransactionType {
 /**
  * Transaction
  *
- * Version: 1 for non-confidential transaction, 2 for confidential transaction
+ * TransactionType: 0 for non-confidential transaction, 1 for confidential transaction
  * TimeStamp:
  * TransactionFees: 8 bytes, clear text, fees * 10^12 - always positive
  * LockTime: 32 bits

--- a/src/Transaction.proto
+++ b/src/Transaction.proto
@@ -53,7 +53,6 @@ message TransactionBroadcast {
     repeated STTransactionEntry STEntries = 5;
     repeated CFTransactionEntry CFEntries = 6;
     bytes Signature = 7; 
-    repeated EntryRangeProof EntryRangeProofs = 8;
 	bytes Init = 9;
 	bytes Data = 10;
 	bytes From = 11;
@@ -79,6 +78,7 @@ message STTransactionEntry {
 message CFTransactionEntry { 
     bytes PubKey = 1;
     bytes PedersenCommit = 2;
+    EntryRangeProof EntryRangeProofs = 8;
 }
 
 /**


### PR DESCRIPTION
- Added From field to know what direction we are going in (due to this we didn't need negative amounts). Also needed to add the From field so we can validate the signature against the From public key.

- Added Init field for smart contract deployment

- Added Data field for smart contract method calls

- Removed Transaction Signature Type as it is just 64 bytes and doesn't need its own object

- Added transaction type enum instead of 'Version'