### PR TITLE
Add delta height request/responses

### DIFF
--- a/src/IPPN.proto
+++ b/src/IPPN.proto
@@ -35,7 +35,7 @@ message PingRequest { }
 
 message PingResponse { }
 
-message DeltaHeightRequest { }
+message LatestDeltaHashRequest { }
 
 message LatestDeltaHashResponse {
     bytes delta_hash = 1;

--- a/src/IPPN.proto
+++ b/src/IPPN.proto
@@ -37,6 +37,6 @@ message PingResponse { }
 
 message DeltaHeightRequest { }
 
-message DeltaHeightResponse {
+message LatestDeltaHashResponse {
     bytes delta_hash = 1;
 }

--- a/src/IPPN.proto
+++ b/src/IPPN.proto
@@ -34,3 +34,9 @@ message PeerNeighborsResponse {
 message PingRequest { }
 
 message PingResponse { }
+
+message DeltaHeightRequest { }
+
+message DeltaHeightResponse {
+    bytes delta_hash = 1;
+}


### PR DESCRIPTION
Purpose of this new protocol message, is to allow nodes to query their current delta height.

When a new node joins the network, it will need to start traversing the delta chain in order to reconstruct the global state. In doing so it has no context of what the current delta is, and must do so by querying its peers. 

The logic here is to ask a random set of peers what are it's latest deltas to take the probabilistic "most popular" current delta heigh so it can begin to sync deltas locally.