### PR TITLE
Add delta history request/response

### DIFF
--- a/src/IPPN.proto
+++ b/src/IPPN.proto
@@ -40,3 +40,12 @@ message LatestDeltaHashRequest { }
 message LatestDeltaHashResponse {
     bytes delta_hash = 1;
 }
+
+message DeltaHistoryRequest {
+    uint32 range = 1;
+    uint32 height = 2;
+}
+
+message DeltaHistoryResponse {
+    repeated bytes delta_hash = 1;
+}


### PR DESCRIPTION
Add IPPN messages for a peer to request an index of another peers delta cids. This protocol will form part of mechanics around initial ledger sync