### PR TITLE
add personal message signature type

### DIFF
--- a/src/Cryptography.proto
+++ b/src/Cryptography.proto
@@ -37,7 +37,7 @@ enum SignatureType {
 	TRANSACTION_CONFIDENTIAL = 2; // Signatures for confidential transactions.
 	PROTOCOL_RPC = 3; // Signatures for rpc messages.
 	PROTOCOL_PEER = 4; // Signatures for peer protocol messages.
-	PERSONAL_MESSAGE = 5; // Signatures for general messages.
+	WEB3_MESSAGE = 5; // Signatures for messages in the wen3 provider.
 }
 
 message SigningContext {

--- a/src/Cryptography.proto
+++ b/src/Cryptography.proto
@@ -37,6 +37,7 @@ enum SignatureType {
 	TRANSACTION_CONFIDENTIAL = 2; // Signatures for confidential transactions.
 	PROTOCOL_RPC = 3; // Signatures for rpc messages.
 	PROTOCOL_PEER = 4; // Signatures for peer protocol messages.
+	PERSONAL_MESSAGE = 5; // Signatures for general messages.
 }
 
 message SigningContext {


### PR DESCRIPTION
This PR adds a new signature type called PERSONAL_MESSAGE that will be used in the context for signatures created using the [signMessage](https://github.com/catalyst-network/Catalyst-js/blob/4297ed7446d3586697f34cf4a5755277fe91dbab/packages/truffle-provider/src/index.ts#L154) method in the catalyst truffle provider.